### PR TITLE
fix broken CDN link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In your HTML file, load the required CSS and JavaScript files:
 ```html
 <script type="module">
     // import the module's entry point (the `App` object)
-    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@1.2.0/predtimechart.js';
+    import App from 'https://cdn.jsdelivr.net/gh/reichlab/predtimechart@2.0.9/dist/predtimechart.js';
 
     // set up _fetchData, _calcUemForecasts (optional), and options
     function _fetchData(isForecast, targetKey, taskIDs, referenceDate) { ... }


### PR DESCRIPTION
The CDN link threw a 404 when I attempted to bundle it.  I looked at https://github.com/reichlab/Covid-19-Hub-Vizualization/blob/178b49fadcce902e38d46ca01326448d69b53d22/index.html#L70C77-L70C111 to figure out the correct usage.